### PR TITLE
Add FastAPI backend skeleton

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,3 @@
+MONGO_URI=mongodb://localhost:27017
+HA_URL=http://localhost:8123
+HA_TOKEN=your-home-assistant-token

--- a/backend/db/__init__.py
+++ b/backend/db/__init__.py
@@ -1,0 +1,1 @@
+"""Package placeholder for future implementation."""

--- a/backend/executor/__init__.py
+++ b/backend/executor/__init__.py
@@ -1,0 +1,1 @@
+"""Package placeholder for future implementation."""

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,15 @@
+"""Application entry point for the AutoHome backend service."""
+
+from fastapi import FastAPI
+
+from routes import api_router
+
+
+def create_app() -> FastAPI:
+    """Create and configure the FastAPI application instance."""
+    app = FastAPI(title="AutoHome Backend", version="0.1.0")
+    app.include_router(api_router)
+    return app
+
+
+app = create_app()

--- a/backend/mock_ha/__init__.py
+++ b/backend/mock_ha/__init__.py
@@ -1,0 +1,1 @@
+"""Package placeholder for future implementation."""

--- a/backend/parser/__init__.py
+++ b/backend/parser/__init__.py
@@ -1,0 +1,1 @@
+"""Package placeholder for future implementation."""

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+pymongo
+requests

--- a/backend/routes/__init__.py
+++ b/backend/routes/__init__.py
@@ -1,0 +1,10 @@
+"""Route registration for the AutoHome backend."""
+
+from fastapi import APIRouter
+
+from .health import router as health_router
+
+api_router = APIRouter()
+api_router.include_router(health_router, prefix="/api")
+
+__all__ = ["api_router"]

--- a/backend/routes/health.py
+++ b/backend/routes/health.py
@@ -1,0 +1,11 @@
+"""Health check endpoint for the AutoHome backend."""
+
+from fastapi import APIRouter
+
+router = APIRouter(tags=["health"])
+
+
+@router.get("/health", summary="Backend health check")
+async def health_check() -> dict[str, str]:
+    """Return the service status."""
+    return {"status": "ok"}

--- a/backend/scheduler/__init__.py
+++ b/backend/scheduler/__init__.py
@@ -1,0 +1,1 @@
+"""Package placeholder for future implementation."""


### PR DESCRIPTION
## Summary
- add a FastAPI application entry point under `backend/main.py`
- scaffold route registration with a health endpoint
- provide placeholder packages plus backend requirements and environment example

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d82eb2f51c832ba745281edf1f3e48