### PR TITLE
Scope guardrail allowed actions to targeted devices

### DIFF
--- a/backend/db/database.py
+++ b/backend/db/database.py
@@ -132,7 +132,7 @@ class InMemoryDatabase:
             name="Thermostat safety",
             description="Restrict thermostat commands to temperature adjustments only.",
             allowed_actions=["set_temperature"],
-            blocked_devices=[thermostat.id],
+            target_devices=[thermostat.id],
         )
 
         self._devices = {

--- a/backend/db/models.py
+++ b/backend/db/models.py
@@ -64,12 +64,20 @@ class Guardrail(BaseModel):
     allowed_actions: Optional[List[str]] = None
     blocked_actions: Optional[List[str]] = None
     blocked_devices: Optional[List[str]] = None
+    target_devices: Optional[List[str]] = None
     max_brightness: Optional[int] = None
 
     def enforce(self, command: Command, device: Device) -> None:
         """Validate a command against the rule, raising when violated."""
 
-        if self.allowed_actions is not None and command.action not in self.allowed_actions:
+        applies_to_device = (
+            self.target_devices is None or device.id in self.target_devices
+        )
+        if (
+            self.allowed_actions is not None
+            and applies_to_device
+            and command.action not in self.allowed_actions
+        ):
             raise GuardrailViolation(
                 self.id,
                 f"Action '{command.action}' is not permitted by guardrail '{self.name}'.",

--- a/backend/routes/schemas.py
+++ b/backend/routes/schemas.py
@@ -19,6 +19,7 @@ class GuardrailCreate(BaseModel):
     allowed_actions: Optional[list[str]] = None
     blocked_actions: Optional[list[str]] = None
     blocked_devices: Optional[list[str]] = None
+    target_devices: Optional[list[str]] = None
     max_brightness: Optional[int] = None
 
 

--- a/tests/test_guardrail_enforcement.py
+++ b/tests/test_guardrail_enforcement.py
@@ -1,0 +1,61 @@
+"""Unit tests covering guardrail enforcement behaviour."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from backend.db.models import Command, Device, Guardrail, GuardrailViolation
+
+
+def _thermostat_guardrail() -> Guardrail:
+    """Create a thermostat guardrail limited to temperature changes."""
+
+    return Guardrail(
+        id="thermostat-allowed-actions",
+        name="Thermostat safety",
+        allowed_actions=["set_temperature"],
+        target_devices=["hallway-thermostat"],
+    )
+
+
+def _thermostat_device() -> Device:
+    return Device(id="hallway-thermostat", name="Hallway Thermostat", type="thermostat")
+
+
+def _light_device() -> Device:
+    return Device(id="living-room-light", name="Living Room Light", type="light")
+
+
+def test_guardrail_allows_temperature_adjustments_for_targeted_thermostat() -> None:
+    guardrail = _thermostat_guardrail()
+    thermostat = _thermostat_device()
+    command = Command(device_id=thermostat.id, action="set_temperature", parameters={"temperature": 23})
+
+    # Should not raise because the thermostat is targeted and the action is explicitly allowed.
+    guardrail.enforce(command, thermostat)
+
+
+def test_guardrail_blocks_disallowed_actions_for_targeted_thermostat() -> None:
+    guardrail = _thermostat_guardrail()
+    thermostat = _thermostat_device()
+    command = Command(device_id=thermostat.id, action="turn_off")
+
+    with pytest.raises(GuardrailViolation):
+        guardrail.enforce(command, thermostat)
+
+
+def test_guardrail_does_not_block_other_devices_when_targeted() -> None:
+    guardrail = _thermostat_guardrail()
+    light = _light_device()
+    command = Command(device_id=light.id, action="turn_on")
+
+    # Guardrail targets only the thermostat, so light commands should proceed unaffected.
+    guardrail.enforce(command, light)
+


### PR DESCRIPTION
## Summary
- add target device scoping to guardrail allowed action enforcement
- expose the new targeting field through the guardrail API schema and seed data
- cover thermostat and light scenarios with unit tests to prove the new behavior

## Testing
- pytest tests/test_guardrail_enforcement.py

------
https://chatgpt.com/codex/tasks/task_e_68d83dcc225c832bace50db08e8f100a